### PR TITLE
Rearrange index to fit in natively with ikiwiki

### DIFF
--- a/pages/index.mdwn
+++ b/pages/index.mdwn
@@ -1,15 +1,14 @@
-<table><tr><td colspan="2">
 
+<p></p>
 <center>
 **Welcome to the Bitcoin Wiki**,
 for all your Bitcoin information needs.  
-Established April 14, 2010.
 
-This wiki is maintained by the Bitcoin community.
+This wiki is maintained by the Bitcoin community, and is the first
+strongly distributed and decentralized
+Bitcoin Wiki.
 </center>
 
-</td></tr>
-<tr><td width=60%>
 [[!img BC_Logo_.png size=64x64 class="floatLeft"]] Bitcoin is a decentralized
 [[digital_currency]] that enables instant payments to anyone, anywhere in
 the world. Bitcoin uses peer-to-peer technology to operate with no central
@@ -29,6 +28,8 @@ Bitcoin is designed around the idea of using cryptography to control the
 creation and transfer of money, rather than relying on central authorities.
 
 
+<table><tr><td colspan="2">
+
 **Why?**
 
 * Bitcoins are sent easily through the Internet, without needing to trust
@@ -46,7 +47,7 @@ creation and transfer of money, rather than relying on central authorities.
 </td><td>
 
 
-**Topic central**
+**Getting Started**
 
 <table><tr><td>
 
@@ -55,22 +56,21 @@ creation and transfer of money, rather than relying on central authorities.
 * [[Myths]]
 * [[Securing_your_wallet]]
 * [[FAQ]]
-
-</td><td>
-
 * [[Technical articles|tags/Technical]]
 * [[Protocol_documentation]]
 * [[Best practices for traders|Secure_Trading]]
 * [[Bitcoin_Improvement_Proposals]]
+
 </td></tr>
+
 <tr><td>
 
 * [[Software]]
 * [[Mining]]
-</td><td>
-
 * [[Clients|tags/Clients]] / [[Frontends|tags/Frontends]]
 * [[Economics|tags/Economics]]
+
+</td></tr></table>
 
 </td></tr></table>
 
@@ -96,10 +96,8 @@ transaction is locked in time by the massive amount of processing power
 that continues to extend the blockchain. Using these techniques, Bitcoin
 provides a fast and extremely reliable payment network that anyone can use.
 
-</td></tr>
 
-
-## Other pages
+## Other Pages
 
 * [[Help|ikiwiki/formatting]] - Documentation on wiki editing.
 * [[About]] - Information on this site.

--- a/pages/local.css
+++ b/pages/local.css
@@ -1,69 +1,125 @@
-html{
-    font-family:sans-serif;
-    -webkit-text-size-adjust:100%;
-    -ms-text-size-adjust:100%;
-    }
-body{
-    font-family:"Helvetica Neue","Helvetica",Arial,sans-serif;
-    font-size:14px;
-     margin: 0 auto;
-    max-width: 800px;
-    padding:0;
-    color:#646464;
-    background-color:#f7f7f7;
-    }
-h1{
-    font-family:'Ubuntu',sans-serif;
-    font-weight:700;
-    color:#0d579b;
-    font-size:160%;
-    margin-top:0;
-    text-align:center;
-    }
-h2{
-    font-family:'Ubuntu',sans-serif;
-    font-weight:700;
-    color:#383838;
-    font-size:130%;
-    text-align:left;
-    }
-h3{
-    color:#383838;
-    font-size:110%;
-    text-align:left;
-    }
-h4{
-    font-size:145%;
-    color:#7b7c7c;
-    margin:20px auto 45px auto;
-    }
-a:link,a:visited,a:active,a.link-js{
-    color:#2c6fad;
-    text-decoration:none;
-    cursor:pointer;
+html {
+    font-family: sans-serif;
+    -webkit-text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    background-color: #f2a900;
 }
-a:link:hover,a:visited:hover,a:active:hover,a.link-js:hover{color:#63a4e1; }
-a img,a:link img,a:visited img,a:active img{ border:0; }
-
-li{margin:10px 0}
+body {
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 15px;
+    margin: 10px auto;
+    max-width: 1200px;
+    width: 85%;
+    padding: 20px 60px 20px 60px;
+    color: #424242;
+    fcolor: #646464;
+    background-color: #fefefe;
+}
+h1 {
+    font-family: 'Source Sans Pro', sans-serif;
+    font-weight: 700;
+    color: #0d579b;
+    font-size: 160%;
+    margin-top: 0;
+    text-align: center;
+}
+h2 {
+    font-family: 'Source Sans Pro', sans-serif;
+    font-weight: 700;
+    color: #383838;
+    font-size: 130%;
+    padding-top: 20px;
+    text-align: left;
+}
+h3 {
+    color: #383838;
+    font-size: 110%;
+    text-align: left;
+}
+h4 {
+    font-size: 145%;
+    color: #7b7c7c;
+    margin: 20px auto 45px auto;
+}
+a:link,
+a:visited,
+a:active,
+a.link-js {
+    color: #2c6fad;
+    text-decoration: none;
+    cursor: pointer;
+}
+a:link:hover,
+a:visited:hover,
+a:active:hover,
+a.link-js:hover {
+    color: #63a4e1;
+}
+a img,
+a:link img,
+a:visited img,
+a:active img {
+    border: 0;
+    padding: 1% 5% 0 1%;
+}
 .header {
-  margin: 5px 5px 0;
+    margin: 5px 5px 0;
+}
+.pagedate {
+    font-size: 75%;
+    text-align: right;
+    margin-right: 40px;
+    color: #787777;
+}
+img.right {
+    display: block;
+    float: right;
+}
+.floatLeft {
+    float: left;
+    clear: left;
+}
+.ref-column {
+    display: inline-block;
+    padding-left: 0.5em;
+    text-align: justify;
+}
+.ref-label {
+    display: inline-block;
+    float: left;
+    padding-right: 0.5em;
+}
+.copyrightinfo {
+    font-size: 10px;
+    margin-top: 1em;
+}
+center {
+    font-size: 18px;
+    margin-bottom: 30px;
+}
+td,
+th {
+    padding: 0 2% 20px 2%;
+    vertical-align: top;
+}
+table {
+    width: 100%;
+    text-align: left;
+    border-spacing: 5px;
+    border-collapse: separate;
+    table-layout: fixed;
+}
+p {
+    padding: 0 0 5px 0;
+}
+td > p {
+    margin: 0 0 0px 0;
+    padding: 0 0 20px 0;
+}
+p:empty {
+    margin: 0;
+    padding: 0;
+    height: 5px;
 }
 
-.pagedate { font-size:75%; text-align:right;margin-right:40px; color: #787777; }
 
-pre,code{font-size:80%}
-
-/*
-.actions {
-  display: none;
-}
-*/
-
-img.right { display: block; float: right; }
-
-.floatLeft { float: left; clear: left; padding: 2px 5px; }
-
-.ref-column { display: inline-block; padding-left: 0.5em; text-align: justify; }
-.ref-label { display: inline-block; float: left; padding-right: 0.5em; }
-.copyrightinfo{font-size: 10px; margin-top: 1em;}

--- a/pages/templates/page.tmpl
+++ b/pages/templates/page.tmpl
@@ -17,6 +17,7 @@
 <TMPL_ELSE>
 <link rel="stylesheet" href="<TMPL_VAR BASEURL>local.css" type="text/css" />
 </TMPL_IF>
+<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro' rel='stylesheet' type='text/css'>
 
 <TMPL_UNLESS DYNAMIC>
 <TMPL_IF EDITURL>


### PR DESCRIPTION
So the current index looks like it was ripped straight off the Bitcoin Wiki.  I think a native reformat is in order.


I've submitted an idea here but it is blocked by a fairly major ikiwiki bug.  If possible I would like some help reproducing.


Seems that changing the table structure of that page also disabled the Markdown rendering for some reason.  This is what the changed page renders as on my machine:
![badmarkdown](https://cloud.githubusercontent.com/assets/565776/15907155/9655eb1e-2d81-11e6-9d63-e77a10404554.PNG)


I haven't yet isolated the minimal change that causes this behavior, but the changes involved are already fairly minimal.


Help on this would be appreciated as I don't have a ton of time to debug, and it seems like understanding this bug will be important to using ikiwiki in production.


NB that this is not ready for merge even after sorting out the mentioned bug (final version may still require minor tweaks).  Meant to be merged on top of #7.